### PR TITLE
Add attention-enhanced UNet with fixed 1024 preprocessing

### DIFF
--- a/nnunetv2/preprocessing/preprocessors/default_preprocessor.py
+++ b/nnunetv2/preprocessing/preprocessors/default_preprocessor.py
@@ -76,6 +76,11 @@ class DefaultPreprocessor(object):
             # in 2d configuration we do not change the spacing between slices
             target_spacing = [original_spacing[0]] + target_spacing
         new_shape = compute_new_shape(data.shape[1:], original_spacing, target_spacing)
+        new_shape = np.array(new_shape, dtype=int)
+        if new_shape.size >= 2:
+            new_shape[-1] = 1024
+            new_shape[-2] = 1024
+        new_shape = tuple(int(i) for i in new_shape)
 
         # normalize
         # normalization MUST happen before resampling or we get huge problems with resampled nonzero masks no

--- a/nnunetv2/training/attention_unet.py
+++ b/nnunetv2/training/attention_unet.py
@@ -1,0 +1,102 @@
+from typing import List, Sequence, Tuple, Union
+
+import torch
+from torch import nn
+
+from dynamic_network_architectures.architectures.unet import PlainConvUNet
+from dynamic_network_architectures.building_blocks.plain_conv_encoder import StackedConvBlocks
+
+
+class SpatialSelfAttention(nn.Module):
+    """Applies multi-head self-attention across spatial positions of a feature map."""
+
+    def __init__(self, channels: int, num_heads: int = 4):
+        super().__init__()
+        num_heads = max(1, num_heads)
+        self.attention = nn.MultiheadAttention(embed_dim=channels, num_heads=num_heads, batch_first=True)
+        self.norm = nn.LayerNorm(channels)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if x.ndim < 3:
+            return x
+        b, c = x.shape[:2]
+        spatial_dims: Sequence[int] = x.shape[2:]
+        flattened = x.view(b, c, -1).permute(0, 2, 1)
+        attended, _ = self.attention(flattened, flattened, flattened, need_weights=False)
+        attended = self.norm(attended)
+        attended = attended.permute(0, 2, 1).contiguous().view(b, c, *spatial_dims)
+        return attended
+
+
+class AttentionUNet(PlainConvUNet):
+    """PlainConvUNet variant with a spatial self-attention bottleneck."""
+
+    def __init__(
+        self,
+        input_channels: int,
+        n_stages: int,
+        features_per_stage: Union[int, List[int], Tuple[int, ...]],
+        conv_op,
+        kernel_sizes: Union[int, List[int], Tuple[int, ...]],
+        strides: Union[int, List[int], Tuple[int, ...]],
+        n_conv_per_stage: Union[int, List[int], Tuple[int, ...]],
+        num_classes: int,
+        n_conv_per_stage_decoder: Union[int, Tuple[int, ...], List[int]],
+        conv_bias: bool = False,
+        norm_op: Union[None, type] = None,
+        norm_op_kwargs: dict = None,
+        dropout_op: Union[None, type] = None,
+        dropout_op_kwargs: dict = None,
+        nonlin: Union[None, type] = None,
+        nonlin_kwargs: dict = None,
+        deep_supervision: bool = False,
+        nonlin_first: bool = False,
+        attention_heads: int = 4,
+    ):
+        super().__init__(
+            input_channels,
+            n_stages,
+            features_per_stage,
+            conv_op,
+            kernel_sizes,
+            strides,
+            n_conv_per_stage,
+            num_classes,
+            n_conv_per_stage_decoder,
+            conv_bias,
+            norm_op,
+            norm_op_kwargs,
+            dropout_op,
+            dropout_op_kwargs,
+            nonlin,
+            nonlin_kwargs,
+            deep_supervision,
+            nonlin_first,
+        )
+
+        bottleneck_channels = self.encoder.output_channels[-1]
+        self.attention_block = SpatialSelfAttention(bottleneck_channels, attention_heads)
+        self.attention_fuse = StackedConvBlocks(
+            num_convs=1,
+            conv_op=self.encoder.conv_op,
+            input_channels=bottleneck_channels * 2,
+            output_channels=bottleneck_channels,
+            kernel_size=self.encoder.kernel_sizes[-1],
+            stride=1,
+            conv_bias=self.encoder.conv_bias,
+            norm_op=self.encoder.norm_op,
+            norm_op_kwargs=self.encoder.norm_op_kwargs,
+            dropout_op=self.encoder.dropout_op,
+            dropout_op_kwargs=self.encoder.dropout_op_kwargs,
+            nonlin=self.encoder.nonlin,
+            nonlin_kwargs=self.encoder.nonlin_kwargs,
+            nonlin_first=nonlin_first,
+        )
+
+    def forward(self, x: torch.Tensor):
+        skips = list(self.encoder(x))
+        bottleneck = skips[-1]
+        attended = self.attention_block(bottleneck)
+        fused = torch.cat((bottleneck, attended), dim=1)
+        skips[-1] = self.attention_fuse(fused)
+        return self.decoder(skips)

--- a/nnunetv2/training/logging/visdom_logger.py
+++ b/nnunetv2/training/logging/visdom_logger.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from typing import Optional, Sequence, Union
+
+import numpy as np
+import torch
+
+try:
+    from visdom import Visdom  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency
+    Visdom = None  # type: ignore
+
+
+TensorLike = Union[torch.Tensor, np.ndarray]
+
+
+class VisdomLogger:
+    """Utility that mirrors selected training artefacts to a Visdom dashboard."""
+
+    def __init__(
+        self,
+        dataset_name: str,
+        env_suffix: str = "",
+        enable: bool = True,
+        port: Optional[int] = None,
+    ) -> None:
+        env_name = f"nnUNet_{dataset_name}"
+        if env_suffix:
+            env_name = f"{env_name}_{env_suffix}"
+
+        self.enabled = bool(enable and Visdom is not None)
+        self._train_logged_epoch: Optional[int] = None
+        self._val_logged_epoch: Optional[int] = None
+        self._vis: Optional[Visdom] = None
+        self._wins: dict[str, str] = {}
+
+        if self.enabled:
+            try:
+                self._vis = Visdom(env=env_name, port=port)
+                if hasattr(self._vis, "check_connection") and not self._vis.check_connection():
+                    raise RuntimeError("Visdom server is not reachable")
+            except Exception as exc:  # pragma: no cover - only triggered when Visdom fails
+                print(f"[Visdom] Disabled: {exc}")
+                self.enabled = False
+                self._vis = None
+
+    def on_epoch_start(self, epoch: int) -> None:
+        if not self.enabled:
+            return
+        self._train_logged_epoch = None
+        self._val_logged_epoch = None
+
+    def log_training_batch(self, data: TensorLike | Sequence[TensorLike], target: TensorLike | Sequence[TensorLike],
+                           output: TensorLike | Sequence[TensorLike], epoch: int) -> None:
+        if not self.enabled or self._train_logged_epoch == epoch:
+            return
+        image = self._prepare_input_image(data)
+        label = self._prepare_segmentation(target, from_one_hot=False)
+        prediction = self._prepare_segmentation(output, from_one_hot=True)
+        self._publish_image("train/input", image, f"Epoch {epoch} – train input")
+        self._publish_image("train/label", label, f"Epoch {epoch} – train label (grayscale)")
+        self._publish_image("train/prediction", prediction, f"Epoch {epoch} – train prediction (grayscale)")
+        self._train_logged_epoch = epoch
+
+    def log_validation_batch(self, data: TensorLike | Sequence[TensorLike],
+                             target: TensorLike | Sequence[TensorLike],
+                             prediction_one_hot: TensorLike | Sequence[TensorLike],
+                             epoch: int) -> None:
+        if not self.enabled or self._val_logged_epoch == epoch:
+            return
+        image = self._prepare_input_image(data)
+        label = self._prepare_segmentation(target, from_one_hot=False)
+        prediction = self._prepare_segmentation(prediction_one_hot, from_one_hot=True)
+        self._publish_image("val/input", image, f"Epoch {epoch} – val input")
+        self._publish_image("val/label", label, f"Epoch {epoch} – val label (grayscale)")
+        self._publish_image("val/prediction", prediction, f"Epoch {epoch} – val prediction (grayscale)")
+        self._val_logged_epoch = epoch
+
+    def _publish_image(self, name: str, image: Optional[np.ndarray], caption: str) -> None:
+        if not self.enabled or image is None or self._vis is None:
+            return
+        try:
+            self._vis.image(image, win=name, opts={"caption": caption})
+        except Exception as exc:  # pragma: no cover - depends on visdom runtime
+            print(f"[Visdom] Failed to publish '{name}': {exc}")
+            self.enabled = False
+
+    @staticmethod
+    def _select_tensor(tensor: TensorLike | Sequence[TensorLike]) -> Optional[torch.Tensor]:
+        if isinstance(tensor, (list, tuple)):
+            if len(tensor) == 0:
+                return None
+            tensor = tensor[0]
+        if tensor is None:
+            return None
+        if isinstance(tensor, np.ndarray):
+            tensor = torch.from_numpy(tensor)
+        assert isinstance(tensor, torch.Tensor)
+        return tensor
+
+    def _prepare_input_image(self, tensor: TensorLike | Sequence[TensorLike]) -> Optional[np.ndarray]:
+        t = self._select_tensor(tensor)
+        if t is None:
+            return None
+        t = t.detach().float().cpu()
+        if t.ndim >= 4:
+            t = t[0]
+        if t.ndim == 3:
+            if t.shape[0] > 1:
+                t = t.mean(0)
+            else:
+                t = t[0]
+        if t.ndim != 2:
+            return None
+        arr = t.numpy()
+        arr = arr - arr.min()
+        max_val = arr.max()
+        if max_val > 0:
+            arr = arr / max_val
+        return arr[np.newaxis, ...].astype(np.float32)
+
+    def _prepare_segmentation(self, tensor: TensorLike | Sequence[TensorLike], *, from_one_hot: bool) -> Optional[np.ndarray]:
+        t = self._select_tensor(tensor)
+        if t is None:
+            return None
+        t = t.detach().float().cpu()
+        if t.ndim >= 4:
+            t = t[0]
+        if from_one_hot:
+            if t.ndim >= 3:
+                seg = torch.argmax(t, dim=0)
+            else:
+                seg = t
+        else:
+            if t.ndim == 3 and t.shape[0] > 1:
+                if torch.all((t == 0) | (t == 1)):
+                    seg = torch.argmax(t, dim=0)
+                else:
+                    seg = t[0]
+            elif t.ndim == 3 and t.shape[0] == 1:
+                seg = t[0]
+            elif t.ndim == 2:
+                seg = t
+            else:
+                seg = t.squeeze()
+        if seg.ndim != 2:
+            seg = seg.squeeze()
+        if seg.ndim != 2:
+            return None
+        if seg.max() > 0:
+            seg = seg / seg.max()
+        arr = seg.numpy().astype(np.float32)
+        return arr[np.newaxis, ...]


### PR DESCRIPTION
## Summary
- enforce 1024×1024 patch planning and preprocessing for 2D experiments
- add an AttentionUNet variant with a self-attention bottleneck and wire it into planning
- integrate Visdom image logging and switch training to AdamW for better stability

## Testing
- python -m compileall nnunetv2/training/attention_unet.py nnunetv2/training/logging/visdom_logger.py

------
https://chatgpt.com/codex/tasks/task_e_68d9e67620a4832ea751b45793471d6a