### PR TITLE
Add ONNX inference pipeline to postprocess script

### DIFF
--- a/prediction_postprecess.py
+++ b/prediction_postprecess.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
-from typing import Iterable, Tuple
+from typing import Iterable, List, Sequence, Tuple
 
 import cv2
 import numpy as np
+import onnxruntime as ort
 
 
 # --------------------------- 基础配色与常量定义 ---------------------------
@@ -28,23 +29,104 @@ TARGET_SIZE: Tuple[int, int] = (1240, 1240)
 
 # --------------------------- 通用工具函数 ---------------------------
 
-def load_label_image(path: Path) -> np.ndarray:
-    """读取 PNG 掩膜并转换为单通道标签图。"""
+def _load_image(path: Path) -> np.ndarray:
+    """读取原始 RGB 图像。"""
 
     image = cv2.imread(str(path), cv2.IMREAD_COLOR)
     if image is None:
         raise FileNotFoundError(f"无法读取图片: {path}")
+    return cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
 
-    h, w, _ = image.shape
-    labels = np.zeros((h, w), dtype=np.uint8)
-    matched = np.zeros((h, w), dtype=bool)
-    # 逐像素匹配颜色到标签，若出现未知颜色则报错提示。
-    for color, label in COLOR_TO_LABEL.items():
-        mask = np.all(image == np.array(color, dtype=np.uint8), axis=-1)
-        labels[mask] = label
-        matched |= mask
-    if not np.all(matched):
-        raise ValueError(f"输入图片存在未知颜色: {path}")
+
+def _pad_to_shape(image: np.ndarray, target_shape: Sequence[int]) -> Tuple[np.ndarray, Tuple[int, int, int, int]]:
+    """将图像填充到目标尺寸，返回填充后的图像与对应的边界。"""
+
+    target_h, target_w = target_shape
+    h, w = image.shape[:2]
+    if h > target_h or w > target_w:
+        raise ValueError(
+            f"图像尺寸 {h}x{w} 超过模型期望尺寸 {target_h}x{target_w}，无法直接填充。"
+        )
+
+    pad_top = (target_h - h) // 2
+    pad_bottom = target_h - h - pad_top
+    pad_left = (target_w - w) // 2
+    pad_right = target_w - w - pad_left
+
+    padded = cv2.copyMakeBorder(
+        image,
+        pad_top,
+        pad_bottom,
+        pad_left,
+        pad_right,
+        borderType=cv2.BORDER_CONSTANT,
+        value=0,
+    )
+
+    return padded, (pad_top, pad_bottom, pad_left, pad_right)
+
+
+def _prepare_model_input(image: np.ndarray, target_shape: Sequence[int]) -> Tuple[np.ndarray, Tuple[int, int, int, int]]:
+    """对图像执行填充与归一化以匹配 ONNX 模型输入。"""
+
+    padded, pads = _pad_to_shape(image, target_shape)
+    input_array = padded.transpose(2, 0, 1).astype(np.float32) / 255.0
+    return np.expand_dims(input_array, axis=0), pads
+
+
+def _load_sessions(onnx_dir: Path) -> List[ort.InferenceSession]:
+    """加载目录中的所有 ONNX 模型。"""
+
+    if onnx_dir.is_file():
+        onnx_files = [onnx_dir]
+    else:
+        onnx_files = sorted(p for p in onnx_dir.glob("*.onnx"))
+
+    if not onnx_files:
+        raise FileNotFoundError(f"在 {onnx_dir} 未找到任何 .onnx 模型")
+
+    sessions: List[ort.InferenceSession] = []
+    for path in onnx_files:
+        sessions.append(ort.InferenceSession(str(path), providers=["CPUExecutionProvider"]))
+    return sessions
+
+
+def _infer_labels(
+    sessions: Sequence[ort.InferenceSession],
+    model_input: np.ndarray,
+    pads: Tuple[int, int, int, int],
+    output_shape: Tuple[int, int],
+) -> np.ndarray:
+    """执行模型推理并转换为标签图。"""
+
+    accumulated = None
+    input_name_cache = [session.get_inputs()[0].name for session in sessions]
+    for session, input_name in zip(sessions, input_name_cache):
+        ort_inputs = {input_name: model_input}
+        output = session.run(None, ort_inputs)[0]
+        if output.ndim != 4:
+            raise ValueError("ONNX 模型输出维度不符，期望形状为 (N, C, H, W)")
+        prediction = output[0]
+        accumulated = prediction if accumulated is None else accumulated + prediction
+
+    mean_prediction = accumulated / len(sessions)
+
+    pad_top, pad_bottom, pad_left, pad_right = pads
+    _, padded_h, padded_w = mean_prediction.shape
+    h, w = output_shape
+
+    start_h = pad_top
+    end_h = padded_h - pad_bottom
+    start_w = pad_left
+    end_w = padded_w - pad_right
+
+    cropped = mean_prediction[:, start_h:end_h, start_w:end_w]
+    if cropped.shape[1:] != (h, w):
+        raise ValueError("裁剪后的尺寸与原始图像不匹配")
+
+    channel_indices = np.argmax(cropped, axis=0).astype(np.uint8)
+    channel_to_label = np.array([0, 3, 2, 1], dtype=np.uint8)
+    labels = channel_to_label[channel_indices]
     return labels
 
 
@@ -328,28 +410,53 @@ def process_label(labels: np.ndarray) -> np.ndarray:
     return labels
 
 
-def process_file(input_path: Path, output_path: Path) -> None:
-    """处理单个文件并写入结果。"""
+def process_file(
+    image_path: Path,
+    sessions: Sequence[ort.InferenceSession],
+    output_path: Path,
+    model_input_shape: Tuple[int, int],
+) -> None:
+    """执行单张图片的推理与后处理。"""
 
-    labels = load_label_image(input_path)
+    image = _load_image(image_path)
+    model_input, pads = _prepare_model_input(image, model_input_shape)
+    labels = _infer_labels(sessions, model_input, pads, image.shape[:2])
     processed = process_label(labels)
     save_label_image(output_path, processed)
 
 
 def gather_images(path: Path) -> Iterable[Path]:
-    """收集需要处理的 PNG 图片路径。"""
+    """收集需要处理的图像路径。"""
 
     if path.is_file():
         return [path]
-    return sorted(p for p in path.glob("*.png"))
+    patterns = ["*.png", "*.jpg", "*.jpeg", "*.bmp", "*.tif", "*.tiff"]
+    files = []
+    for pattern in patterns:
+        files.extend(path.glob(pattern))
+    # 使用 set 去重后再排序，避免相同后缀大小写造成的重复
+    return sorted(set(files))
 
 
 def parse_args() -> argparse.Namespace:
     """解析命令行参数。"""
 
-    parser = argparse.ArgumentParser(description="对分割掩膜执行后处理")
-    parser.add_argument("input", type=Path, help="输入 PNG 文件或包含 PNG 的文件夹")
-    parser.add_argument("output", type=Path, help="输出文件或目录")
+    parser = argparse.ArgumentParser(description="对模型预测执行推理与后处理")
+    parser.add_argument("--onnx_dir", type=Path, required=True, help="包含 ONNX 模型的文件或目录")
+    parser.add_argument("--images_dir", type=Path, required=True, help="输入原始图像路径或目录")
+    parser.add_argument("--output_dir", type=Path, required=True, help="输出目录")
+    parser.add_argument(
+        "--model_input_height",
+        type=int,
+        default=1280,
+        help="ONNX 模型期望的高度 (默认: 1280)",
+    )
+    parser.add_argument(
+        "--model_input_width",
+        type=int,
+        default=1280,
+        help="ONNX 模型期望的宽度 (默认: 1280)",
+    )
     return parser.parse_args()
 
 
@@ -357,21 +464,19 @@ def main() -> None:
     """脚本入口：根据输入类型批量或单张处理并保存。"""
 
     args = parse_args()
-    inputs = list(gather_images(args.input))
-    if not inputs:
-        raise FileNotFoundError("未找到任何 PNG 输入文件")
 
-    treat_as_dir = args.output.is_dir() or args.output.suffix == "" or len(inputs) > 1
-    if treat_as_dir:
-        args.output.mkdir(parents=True, exist_ok=True)
-        for path in inputs:
-            output_path = args.output / path.name
-            process_file(path, output_path)
-    else:
-        if len(inputs) > 1:
-            raise ValueError("当输入为多个文件时，输出应为目录")
-        args.output.parent.mkdir(parents=True, exist_ok=True)
-        process_file(inputs[0], args.output)
+    sessions = _load_sessions(args.onnx_dir)
+    images = list(gather_images(args.images_dir))
+    if not images:
+        raise FileNotFoundError("未找到任何输入图像")
+
+    model_shape = (args.model_input_height, args.model_input_width)
+    output_dir = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for image_path in images:
+        output_path = output_dir / (image_path.stem + ".png")
+        process_file(image_path, sessions, output_path, model_shape)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- load ONNX models alongside original images inside `prediction_postprecess.py`
- add preprocessing, padding, and decoding of 4-channel one-hot outputs into label maps
- reuse the existing postprocessing pipeline to save colored masks per input image

## Testing
- python -m compileall prediction_postprecess.py

------
https://chatgpt.com/codex/tasks/task_e_68edf3878a84832e8ed933afdfbc8f92